### PR TITLE
fix typo in variable name

### DIFF
--- a/metacritic/app.js
+++ b/metacritic/app.js
@@ -207,7 +207,7 @@ function RequestSearch(url, cb, page) {
             cb(err);
         }
     }).on('error', function (e) {
-        cb(error);
+        cb(e);
     }).end();
 }
 


### PR DESCRIPTION
This was causing an error in certain conditions:
```
ReferenceError: error is not defined
    at Request.<anonymous> (node_modules/metacritic/app.js:210:12)
```